### PR TITLE
Changed Status LEDs to Media Bar

### DIFF
--- a/alienfx/core/controller.py
+++ b/alienfx/core/controller.py
@@ -58,7 +58,7 @@ class AlienFXController:
     ZONE_ALIEN_HEAD = "Alien Head"
     ZONE_LOGO = "Logo"
     ZONE_TOUCH_PAD = "Touchpad"
-    ZONE_STATUS_LEDS = "Status LEDs"
+    ZONE_MEDIA_BAR = "Media Bar"
     ZONE_POWER_BUTTON = "Power Button"
     ZONE_HDD_LEDS = "HDD LEDs"
         

--- a/alienfx/core/controller.py
+++ b/alienfx/core/controller.py
@@ -59,6 +59,7 @@ class AlienFXController:
     ZONE_LOGO = "Logo"
     ZONE_TOUCH_PAD = "Touchpad"
     ZONE_MEDIA_BAR = "Media Bar"
+    ZONE_STATUS_LEDS = "Status LEDs"
     ZONE_POWER_BUTTON = "Power Button"
     ZONE_HDD_LEDS = "HDD LEDs"
         

--- a/alienfx/core/controller_m17x.py
+++ b/alienfx/core/controller_m17x.py
@@ -52,7 +52,7 @@ class AlienFXControllerM17x(alienfx_controller.AlienFXController):
     ALIEN_HEAD = 0x0080
     LOGO = 0x0100
     TOUCH_PAD = 0x0200
-    STATUS_LEDS = 0x0800
+    MEDIA_BAR = 0x0800
     POWER_BUTTON = 0x2000
     HDD_LEDS = 0x4000
 
@@ -88,7 +88,7 @@ class AlienFXControllerM17x(alienfx_controller.AlienFXController):
             self.ZONE_ALIEN_HEAD: self.ALIEN_HEAD,
             self.ZONE_LOGO: self.LOGO,
             self.ZONE_TOUCH_PAD: self.TOUCH_PAD,
-            self.ZONE_STATUS_LEDS: self.STATUS_LEDS,
+            self.ZONE_MEDIA_BAR: self.MEDIA_BAR,
             self.ZONE_POWER_BUTTON: self.POWER_BUTTON,
             self.ZONE_HDD_LEDS: self.HDD_LEDS,
         }


### PR DESCRIPTION
I changed the zone name "Status LEDs" to "Media Bar" for the m17x.
