### PR TITLE
Support for 13r2 Laptop

### DIFF
--- a/README
+++ b/README
@@ -59,6 +59,7 @@ At present, AlienFX supports and has been tested on the following Alienware mode
 
 1. M14xR1 laptop - support by Ashwin Menon (https://github.com/ashwinm76)
 2. M17x Laptop - support by trackmastersteve (https://github.com/trackmastersteve)
+3. 13r2 Laptop - support by Simon Wood (https://github.com/mungewell)
 
 To add support for a different model of Alienware computer, do the following:
 

--- a/alienfx/core/controller.py
+++ b/alienfx/core/controller.py
@@ -157,7 +157,8 @@ class AlienFXController:
         """
         zones = 0
         for zone in zone_names:
-            zones |= self.zone_map[zone]
+            if zone in self.zone_map:
+                zones |= self.zone_map[zone]
         return zones
         
     def _get_reset_code(self, reset_name):

--- a/alienfx/core/controller_13r2.py
+++ b/alienfx/core/controller_13r2.py
@@ -1,0 +1,116 @@
+#
+# controller_13r2.py
+#
+# Copyright (C) 2013-2014 Ashwin Menon <ashwin.menon@gmail.com>
+#
+# Alienfx is free software.
+#
+# You may redistribute it and/or modify it under the terms of the
+# GNU General Public License, as published by the Free Software
+# Foundation; either version 3 of the License, or (at your option)
+# any later version.
+#
+# Alienfx is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with alienfx.    If not, write to:
+# 	The Free Software Foundation, Inc.,
+# 	51 Franklin Street, Fifth Floor
+# 	Boston, MA  02110-1301, USA.
+#
+
+""" Specialization of the AlienFxController class for the M17x controller.
+
+This module provides the following classes:
+AlienFXControllerM17x : M17x controller
+"""
+
+import alienfx.core.controller as alienfx_controller
+
+class AlienFXController13r2(alienfx_controller.AlienFXController):
+    
+    """ Specialization of the AlienFxController class for the M17x controller.
+    """
+    
+    # Speed capabilities. The higher the number, the slower the speed of 
+    # blink/morph actions. The min speed is selected by trial and error as 
+    # the lowest value that will not result in strange blink/morph behaviour.
+    DEFAULT_SPEED = 200
+    MIN_SPEED = 50
+    
+    # Zone codes
+    LEFT_KEYBOARD = 0x0008
+    MIDDLE_LEFT_KEYBOARD = 0x0004
+    MIDDLE_RIGHT_KEYBOARD = 0x0002
+    RIGHT_KEYBOARD = 0x0001
+    # External 'Alien Head' and 'Slashes' change together
+    ALIEN_HEAD = 0x0020
+    # 'Alienware' below screen
+    LOGO = 0x0040
+    # Windows the next 3 as a single 'Zone 8'
+    HDD_LED = 0x0200
+    WIFI_LED = 0x0400
+    CAPS_LED = 0x0080
+    TOUCH_PAD = HDD_LED | WIFI_LED | CAPS_LED
+    POWER_BUTTON = 0x0100
+
+    # Reset codes
+    RESET_ALL_LIGHTS_OFF = 3
+    RESET_ALL_LIGHTS_ON = 4
+    
+    # State codes
+    BOOT = 1
+    AC_SLEEP = 2
+    AC_CHARGED = 5
+    AC_CHARGING = 6
+    BATTERY_SLEEP = 7
+    BATTERY_ON = 8
+    BATTERY_CRITICAL = 9
+    
+    def __init__(self):
+        alienfx_controller.AlienFXController.__init__(self)
+        self.name = "Alienware 13R2"
+        
+        # USB VID and PID
+        self.vendor_id = 0x187c
+        self.product_id = 0x0527
+        
+        # map the zone names to their codes
+        self.zone_map = {
+            self.ZONE_LEFT_KEYBOARD: self.LEFT_KEYBOARD,
+            self.ZONE_MIDDLE_LEFT_KEYBOARD: self.MIDDLE_LEFT_KEYBOARD,
+            self.ZONE_MIDDLE_RIGHT_KEYBOARD: self.MIDDLE_RIGHT_KEYBOARD,
+            self.ZONE_RIGHT_KEYBOARD: self.RIGHT_KEYBOARD,
+            self.ZONE_ALIEN_HEAD: self.ALIEN_HEAD,
+            self.ZONE_LOGO: self.LOGO,
+            self.ZONE_TOUCH_PAD: self.TOUCH_PAD,
+            self.ZONE_POWER_BUTTON: self.POWER_BUTTON,
+        }
+        
+        # zones that have special behaviour in the different power states
+        self.power_zones = [
+            self.ZONE_POWER_BUTTON,
+        ]
+        
+        # map the reset names to their codes
+        self.reset_types = {
+            self.RESET_ALL_LIGHTS_OFF: "all-lights-off",
+            self.RESET_ALL_LIGHTS_ON: "all-lights-on"
+        }
+        
+        # map the state names to their codes
+        self.state_map = {
+            self.STATE_BOOT: self.BOOT,
+            self.STATE_AC_SLEEP: self.AC_SLEEP,
+            self.STATE_AC_CHARGED: self.AC_CHARGED,
+            self.STATE_AC_CHARGING: self.AC_CHARGING,
+            self.STATE_BATTERY_SLEEP: self.BATTERY_SLEEP,
+            self.STATE_BATTERY_ON: self.BATTERY_ON,
+            self.STATE_BATTERY_CRITICAL: self.BATTERY_CRITICAL
+        }
+
+alienfx_controller.AlienFXController.supported_controllers.append(
+    AlienFXController13r2())

--- a/alienfx/core/prober.py
+++ b/alienfx/core/prober.py
@@ -35,6 +35,7 @@ from alienfx.core.controller import AlienFXController as AlienFXController
 """ Import all subclasses of AlienFXController here. """
 import alienfx.core.controller_m14xr1
 import alienfx.core.controller_m17x
+import alienfx.core.controller_13r2
 
 class AlienFXProber:
     

--- a/alienfx/data/etc/udev/rules.d/10-alienfx.rules
+++ b/alienfx/data/etc/udev/rules.d/10-alienfx.rules
@@ -7,3 +7,6 @@ SUBSYSTEM=="usb", ATTR{idVendor}=="187c", ATTR{idProduct}=="0521", MODE:="666", 
 
 # USB device 0x187c:0x0512 (AlienFX controller for M17x laptop)
 SUBSYSTEM=="usb", ATTR{idVendor}=="187c", ATTR{idProduct}=="0512", MODE:="666", GROUP="users"
+
+# USB device 0x187c:0x0527 (AlienFX controller for 13r2 laptop)
+SUBSYSTEM=="usb", ATTR{idVendor}=="187c", ATTR{idProduct}=="0527", MODE:="666", GROUP="users"

--- a/alienfx/ui/gtkui/gtkui.py
+++ b/alienfx/ui/gtkui/gtkui.py
@@ -266,7 +266,7 @@ class AlienFXApp(Gtk.Application):
                     a = AlienFXActions()
                     a.actions = self.themefile.get_zone_actions(state, zone)
                     power_zone_list_store.append([state, a])
-            else:
+            elif zone in self.controller.zone_map:
                 a = AlienFXActions()
                 a.actions = self.themefile.get_zone_actions(self.controller.STATE_BOOT, zone)
                 normal_zone_list_store.append([zone, a])


### PR DESCRIPTION
Support for 13r2 Laptop

Note: I used 'TOUCHPAD_LEDS' for HDD/WiFi/Caps LEDs as 'STATUS_LEDS' are not editable in the GUI.