### PR TITLE
Syntax correction (missing parentheses)

### DIFF
--- a/alienfx/core/prober.py
+++ b/alienfx/core/prober.py
@@ -86,6 +86,6 @@ class AlienFXProber(object):
                 if dev.idVendor is not None:
                     if dev.idVendor == vid:
                         devices.append(dev)
-        if devices.__len__ > 0:
+        if len(devices):
             return devices
         return None


### PR DESCRIPTION
Minor correction - parentheses were missing in method call, replaced by the appropriate function and simplified. 