### PR TITLE
Area51r2

### DIFF
--- a/alienfx/core/controller_area51_r2.py
+++ b/alienfx/core/controller_area51_r2.py
@@ -1,0 +1,121 @@
+#
+# controller_area51_r2.py
+#
+# Copyright (C) 2013-2014 Ashwin Menon <ashwin.menon@gmail.com>
+# Copyright (C) 2015-2018 Track Master Steve <trackmastersteve@gmail.com>
+#
+# Alienfx is free software.
+#
+# You may redistribute it and/or modify it under the terms of the
+# GNU General Public License, as published by the Free Software
+# Foundation; either version 3 of the License, or (at your option)
+# any later version.
+#
+# Alienfx is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with alienfx.    If not, write to:
+# 	The Free Software Foundation, Inc.,
+# 	51 Franklin Street, Fifth Floor
+# 	Boston, MA  02110-1301, USA.
+#
+
+""" Specialization of the AlienFxController class for the Area51 controller.
+
+This module provides the following classes:
+AlienFXControllerArea51R2 : Area51 controller
+"""
+
+import alienfx.core.controller as alienfx_controller
+
+class AlienFXControllerArea51R2(alienfx_controller.AlienFXController):
+    
+    """ Specialization of the AlienFxController class for the Area51 R2 controller.
+    """
+    
+    # Speed capabilities. The higher the number, the slower the speed of 
+    # blink/morph actions. The min speed is selected by trial and error as 
+    # the lowest value that will not result in strange blink/morph behaviour.
+    DEFAULT_SPEED = 200
+    MIN_SPEED = 50
+    
+    # Zone codes
+    LEFT_KEYBOARD = 0x0040
+    MIDDLE_LEFT_KEYBOARD = 0x0080
+    MIDDLE_RIGHT_KEYBOARD = 0x0000
+    RIGHT_KEYBOARD = 0x0020
+    # Both speakers change together
+    RIGHT_SPEAKER = 0x0800
+    LEFT_SPEAKER = 0x1000
+    ALIEN_HEAD = 0x0400
+    LOGO = 0x0004
+    TOUCH_PAD = 0x0002
+    MEDIA_BAR = 0x0001
+    POWER_BUTTON = 0x0000
+    HDD_LEDS = 0x0000
+
+    # Reset codes
+    RESET_ALL_LIGHTS_OFF = 3
+    RESET_ALL_LIGHTS_ON = 4
+    
+    # State codes
+    BOOT = 1
+    AC_SLEEP = 2
+    AC_CHARGED = 5
+    AC_CHARGING = 6
+    BATTERY_SLEEP = 7
+    BATTERY_ON = 8
+    BATTERY_CRITICAL = 9
+    
+    def __init__(self):
+        alienfx_controller.AlienFXController.__init__(self)
+        self.name = "Alienware Area51 R2"
+        
+        # USB VID and PID
+        self.vendor_id = 0x187c
+        self.product_id = 0x0526
+        
+        # map the zone names to their codes
+        self.zone_map = {
+            self.ZONE_LEFT_KEYBOARD: self.LEFT_KEYBOARD,
+            self.ZONE_MIDDLE_LEFT_KEYBOARD: self.MIDDLE_LEFT_KEYBOARD,
+            self.ZONE_MIDDLE_RIGHT_KEYBOARD: self.MIDDLE_RIGHT_KEYBOARD,
+            self.ZONE_RIGHT_KEYBOARD: self.RIGHT_KEYBOARD,
+            self.ZONE_RIGHT_SPEAKER: self.RIGHT_SPEAKER,
+            self.ZONE_LEFT_SPEAKER: self.LEFT_SPEAKER,
+            self.ZONE_ALIEN_HEAD: self.ALIEN_HEAD,
+            self.ZONE_LOGO: self.LOGO,
+            self.ZONE_TOUCH_PAD: self.TOUCH_PAD,
+            self.ZONE_MEDIA_BAR: self.MEDIA_BAR,
+            self.ZONE_POWER_BUTTON: self.POWER_BUTTON,
+            self.ZONE_HDD_LEDS: self.HDD_LEDS,
+        }
+        
+        # zones that have special behaviour in the different power states
+        self.power_zones = [
+            self.ZONE_POWER_BUTTON,
+            self.ZONE_HDD_LEDS
+        ]
+        
+        # map the reset names to their codes
+        self.reset_types = {
+            self.RESET_ALL_LIGHTS_OFF: "all-lights-off",
+            self.RESET_ALL_LIGHTS_ON: "all-lights-on"
+        }
+        
+        # map the state names to their codes
+        self.state_map = {
+            self.STATE_BOOT: self.BOOT,
+            self.STATE_AC_SLEEP: self.AC_SLEEP,
+            self.STATE_AC_CHARGED: self.AC_CHARGED,
+            self.STATE_AC_CHARGING: self.AC_CHARGING,
+            self.STATE_BATTERY_SLEEP: self.BATTERY_SLEEP,
+            self.STATE_BATTERY_ON: self.BATTERY_ON,
+            self.STATE_BATTERY_CRITICAL: self.BATTERY_CRITICAL
+        }
+
+alienfx_controller.AlienFXController.supported_controllers.append(
+    AlienFXControllerArea51R2())

--- a/alienfx/core/prober.py
+++ b/alienfx/core/prober.py
@@ -38,6 +38,7 @@ from alienfx.core.controller import AlienFXController as AlienFXController
 
 """ Import all subclasses of AlienFXController here. """
 import alienfx.core.controller_area51
+import alienfx.core.controller_area51_r2
 import alienfx.core.controller_aurora
 import alienfx.core.controller_m11xr1
 import alienfx.core.controller_m11xr2

--- a/alienfx/data/etc/udev/rules.d/10-alienfx.rules
+++ b/alienfx/data/etc/udev/rules.d/10-alienfx.rules
@@ -5,6 +5,9 @@
 # USB device 0x187c:0x0511 (AlienFX controller for Area51 desktop)
 SUBSYSTEM=="usb", ATTR{idVendor}=="187c", ATTR{idProduct}=="0511", MODE:="666", GROUP="users"
 
+# USB device 0x187c:0x0526 (AlienFX controller for Area51 R2 Desktop)
+SUBSYSTEM=="usb", ATTR(idVender)=="187c", ATTR(idProduct)=="0526", MODE:="666", GROUP="users"
+
 # USB device 0x187c:0x0514 (AlienFX controller for M11xR1 laptop)
 SUBSYSTEM=="usb", ATTR{idVendor}=="187c", ATTR{idProduct}=="0514", MODE:="666", GROUP="users"
 

--- a/docs/Knowledgebase/Devicelist.md
+++ b/docs/Knowledgebase/Devicelist.md
@@ -20,3 +20,4 @@ device list
 | 14 | ? | controller_m17xr3.py |  | Laptop | Needs the correct Zone Codes | 0x0520 | 4 |  |
 | 15 | Alienware 17 R4 | controller_m17xr4.py | Q3/2016 | Laptop | support by [Dennis Marx](https://github.com/derco0n) | 0x0530 | 8 | ![Alienware 17 R4](https://github.com/trackmastersteve/alienfx/blob/master/docs/Knowledgebase/images/devices/aw17r4.png) |
 | 16 | ? | controller_m18xr2.py |  | Laptop | Needs the correct Zone Codes | 0x0518 | 4 |  |
+| 17 | ? | controller_area51_r2.py | | Desktop | Unknown | 0x0526 | 4 | |


### PR DESCRIPTION
PR for an alienware area51 r2.

Notes:
These are your 9 zonecodes for the current controller ("VID: 0x187c / DEV: 0x0526"):
left rear: 0x0004
alien head: 0x0400
left forward: 0x0002
left top: 0x0001
front left: 0x1000
right top: 0x0020
right forward: 0x0080
right rear: 0x0040
front right: 0x0800