### PR TITLE
One fix for M14x R<1-3>, one feature for GTK GUI

### DIFF
--- a/alienfx/core/controller_m14xr1.py
+++ b/alienfx/core/controller_m14xr1.py
@@ -88,7 +88,7 @@ class AlienFXControllerM14XR1(alienfx_controller.AlienFXController):
             self.ZONE_TOUCH_PAD: self.TOUCH_PAD,
             self.ZONE_STATUS_LEDS: self.STATUS_LEDS,
             self.ZONE_POWER_BUTTON: self.POWER_BUTTON,
-            self.ZONE_HDD_LEDS: self.HDD_LEDS,
+            self.ZONE_HDD_LEDS: self.HDD_LEDS
         }
         
         # zones that have special behaviour in the different power states

--- a/alienfx/core/controller_m14xr1.py
+++ b/alienfx/core/controller_m14xr1.py
@@ -94,7 +94,8 @@ class AlienFXControllerM14XR1(alienfx_controller.AlienFXController):
         # zones that have special behaviour in the different power states
         self.power_zones = [
             self.ZONE_POWER_BUTTON,
-            self.ZONE_HDD_LEDS
+            self.ZONE_HDD_LEDS,
+            self.ZONE_STATUS_LEDS
         ]
         
         # map the reset names to their codes

--- a/alienfx/core/controller_m14xr2.py
+++ b/alienfx/core/controller_m14xr2.py
@@ -96,7 +96,8 @@ class AlienFXControllerM14XR2(alienfx_controller.AlienFXController):
         # zones that have special behaviour in the different power states
         self.power_zones = [
             self.ZONE_POWER_BUTTON,
-            self.ZONE_HDD_LEDS
+            self.ZONE_HDD_LEDS,
+            self.ZONE_STATUS_LEDS
         ]
         
         # map the reset names to their codes

--- a/alienfx/core/controller_m14xr2.py
+++ b/alienfx/core/controller_m14xr2.py
@@ -90,7 +90,7 @@ class AlienFXControllerM14XR2(alienfx_controller.AlienFXController):
             self.ZONE_TOUCH_PAD: self.TOUCH_PAD,
             self.ZONE_STATUS_LEDS: self.STATUS_LEDS,
             self.ZONE_POWER_BUTTON: self.POWER_BUTTON,
-            self.ZONE_HDD_LEDS: self.HDD_LEDS,
+            self.ZONE_HDD_LEDS: self.HDD_LEDS
         }
         
         # zones that have special behaviour in the different power states

--- a/alienfx/core/controller_m14xr3.py
+++ b/alienfx/core/controller_m14xr3.py
@@ -88,7 +88,7 @@ class AlienFXControllerM14XR3(alienfx_controller.AlienFXController):
             self.ZONE_TOUCH_PAD: self.TOUCH_PAD,
             self.ZONE_STATUS_LEDS: self.STATUS_LEDS,
             self.ZONE_POWER_BUTTON: self.POWER_BUTTON,
-            self.ZONE_HDD_LEDS: self.HDD_LEDS,
+            self.ZONE_HDD_LEDS: self.HDD_LEDS
         }
         
         # zones that have special behaviour in the different power states

--- a/alienfx/core/controller_m14xr3.py
+++ b/alienfx/core/controller_m14xr3.py
@@ -94,7 +94,8 @@ class AlienFXControllerM14XR3(alienfx_controller.AlienFXController):
         # zones that have special behaviour in the different power states
         self.power_zones = [
             self.ZONE_POWER_BUTTON,
-            self.ZONE_HDD_LEDS
+            self.ZONE_HDD_LEDS,
+            self.ZONE_STATUS_LEDS
         ]
         
         # map the reset names to their codes

--- a/alienfx/data/themes/m14xr2_dark.json
+++ b/alienfx/data/themes/m14xr2_dark.json
@@ -1,0 +1,409 @@
+{
+    "speed": 200,
+    "Boot": [
+        {
+            "zones": [
+                "Left Display"
+            ],
+            "loop": [
+                {
+                    "type": "fixed",
+                    "colours": [
+                        [
+                            0,
+                            0,
+                            15
+                        ]
+                    ]
+                }
+            ]
+        },
+        {
+            "zones": [
+                "Right Display"
+            ],
+            "loop": [
+                {
+                    "type": "fixed",
+                    "colours": [
+                        [
+                            0,
+                            0,
+                            15
+                        ]
+                    ]
+                }
+            ]
+        },
+        {
+            "zones": [
+                "Right Keyboard"
+            ],
+            "loop": [
+                {
+                    "type": "fixed",
+                    "colours": [
+                        [
+                            0,
+                            0,
+                            0
+                        ]
+                    ]
+                }
+            ]
+        },
+        {
+            "zones": [
+                "Middle-right Keyboard"
+            ],
+            "loop": [
+                {
+                    "type": "fixed",
+                    "colours": [
+                        [
+                            0,
+                            0,
+                            0
+                        ]
+                    ]
+                }
+            ]
+        },
+        {
+            "zones": [
+                "Middle-left Keyboard"
+            ],
+            "loop": [
+                {
+                    "type": "fixed",
+                    "colours": [
+                        [
+                            0,
+                            0,
+                            0
+                        ]
+                    ]
+                }
+            ]
+        },
+        {
+            "zones": [
+                "Left Keyboard"
+            ],
+            "loop": [
+                {
+                    "type": "fixed",
+                    "colours": [
+                        [
+                            0,
+                            0,
+                            0
+                        ]
+                    ]
+                }
+            ]
+        },
+        {
+            "zones": [
+                "Left Speaker",
+                "Right Speaker"
+            ],
+            "loop": [
+                {
+                    "type": "fixed",
+                    "colours": [
+                        [
+                            0,
+                            0,
+                            0
+                        ]
+                    ]
+                }
+            ]
+        },
+        {
+            "zones": [
+                "Alien Head"
+            ],
+            "loop": [
+                {
+                    "type": "fixed",
+                    "colours": [
+                        [
+                            0,
+                            0,
+                            15
+                        ]
+                    ]
+                }
+            ]
+        },
+        {
+            "zones": [
+                "Logo"
+            ],
+            "loop": [
+                {
+                    "type": "fixed",
+                    "colours": [
+                        [
+                            0,
+                            0,
+                            0
+                        ]
+                    ]
+                }
+            ]
+        },
+        {
+            "zones": [
+                "Touchpad"
+            ],
+            "loop": [
+                {
+                    "type": "fixed",
+                    "colours": [
+                        [
+                            0,
+                            0,
+                            0
+                        ]
+                    ]
+                }
+            ]
+        }
+    ],
+    "AC Sleep": [
+        {
+            "zones": [
+                "Power Button",
+                "HDD LEDs"
+            ],
+            "loop": [
+                {
+                    "type": "morph",
+                    "colours": [
+                        [
+                            0,
+                            0,
+                            15
+                        ],
+                        [
+                            0,
+                            0,
+                            0
+                        ]
+                    ]
+                },
+                {
+                    "type": "morph",
+                    "colours": [
+                        [
+                            0,
+                            0,
+                            0
+                        ],
+                        [
+                            0,
+                            0,
+                            15
+                        ]
+                    ]
+                }
+            ]
+        },
+        {
+            "zones": [
+                "Left Keyboard",
+                "Middle-left Keyboard",
+                "Middle-right Keyboard",
+                "Right Keyboard",
+                "Right Speaker",
+                "Left Speaker",
+                "Logo",
+                "Touchpad",
+                "Status LEDs"
+            ],
+            "loop": [
+                {
+                    "type": "fixed",
+                    "colours": [
+                        [
+                            0,
+                            0,
+                            0
+                        ]
+                    ]
+                }
+            ]
+        }
+    ],
+    "AC Charged": [
+        {
+            "zones": [
+                "Power Button",
+                "HDD LEDs",
+                "Status LEDs"
+            ],
+            "loop": [
+                {
+                    "type": "fixed",
+                    "colours": [
+                        [
+                            0,
+                            0,
+                            15
+                        ]
+                    ]
+                }
+            ]
+        }
+    ],
+    "AC Charging": [
+        {
+            "zones": [
+                "Power Button",
+                "HDD LEDs",
+                "Status LEDs"
+            ],
+            "loop": [
+                {
+                    "type": "morph",
+                    "colours": [
+                        [
+                            0,
+                            0,
+                            15
+                        ],
+                        [
+                            15,
+                            9,
+                            0
+                        ]
+                    ]
+                },
+                {
+                    "type": "morph",
+                    "colours": [
+                        [
+                            15,
+                            9,
+                            0
+                        ],
+                        [
+                            0,
+                            0,
+                            15
+                        ]
+                    ]
+                }
+            ]
+        }
+    ],
+    "Battery Sleep": [
+        {
+            "zones": [
+                "Power Button",
+                "HDD LEDs"
+            ],
+            "loop": [
+                {
+                    "type": "morph",
+                    "colours": [
+                        [
+                            15,
+                            9,
+                            0
+                        ],
+                        [
+                            0,
+                            0,
+                            0
+                        ]
+                    ]
+                },
+                {
+                    "type": "morph",
+                    "colours": [
+                        [
+                            0,
+                            0,
+                            0
+                        ],
+                        [
+                            15,
+                            9,
+                            0
+                        ]
+                    ]
+                }
+            ]
+        },
+        {
+            "zones": [
+                "Left Keyboard",
+                "Middle-left Keyboard",
+                "Middle-right Keyboard",
+                "Right Keyboard",
+                "Right Speaker",
+                "Left Speaker",
+                "Logo",
+                "Touchpad",
+                "Status LEDs"
+            ],
+            "loop": [
+                {
+                    "type": "fixed",
+                    "colours": [
+                        [
+                            0,
+                            0,
+                            0
+                        ]
+                    ]
+                }
+            ]
+        }
+    ],
+    "Battery On": [
+        {
+            "zones": [
+                "Power Button",
+                "HDD LEDs",
+                "Status LEDs"
+            ],
+            "loop": [
+                {
+                    "type": "fixed",
+                    "colours": [
+                        [
+                            15,
+                            9,
+                            0
+                        ]
+                    ]
+                }
+            ]
+        }
+    ],
+    "Battery Critical": [
+        {
+            "zones": [
+                "Power Button",
+                "HDD LEDs"
+            ],
+            "loop": [
+                {
+                    "type": "blink",
+                    "colours": [
+                        [
+                            15,
+                            9,
+                            0
+                        ]
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/alienfx/data/themes/m14xr2_default.json
+++ b/alienfx/data/themes/m14xr2_default.json
@@ -1,0 +1,191 @@
+{
+    "speed": 200,
+    "Boot": [
+        {
+            "zones": ["Left Display"],
+            "loop": [
+                {
+                    "type": "fixed",
+                    "colours": [ [0,0,15] ]
+                }
+            ]
+        },
+        {
+            "zones": ["Right Display"],
+            "loop": [
+                {
+                    "type": "fixed",
+                    "colours": [ [0,0,15] ]
+                }
+            ]
+        },
+        {
+            "zones": ["Right Keyboard"],
+            "loop": [
+                {
+                    "type": "fixed",
+                    "colours": [ [0,0,15] ]
+                }
+            ]
+        },
+        {
+            "zones": ["Middle-right Keyboard"],
+            "loop": [
+                {
+                    "type": "fixed",
+                    "colours": [ [0,0,15] ]
+                }
+            ]
+        },
+        {
+            "zones": ["Middle-left Keyboard"],
+            "loop": [
+                {
+                    "type": "fixed",
+                    "colours": [ [0,0,15] ]
+                }
+            ]
+        },
+        {
+            "zones": ["Left Keyboard"],
+            "loop": [
+                {
+                    "type": "fixed",
+                    "colours": [ [0,0,15] ]
+                }
+            ]
+        },
+        {
+            "zones": ["Left Speaker", "Right Speaker"],
+            "loop": [
+                {
+                    "type": "fixed",
+                    "colours": [ [0,0,15] ]
+                }
+            ]
+        },
+        {
+            "zones": ["Alien Head"],
+            "loop": [
+                {
+                    "type": "fixed",
+                    "colours": [ [0,0,15] ]
+                }
+            ]
+        },
+        {
+            "zones": ["Logo"],
+            "loop": [
+                {
+                    "type": "fixed",
+                    "colours": [ [0,0,15] ]
+                }
+            ]
+        },
+        {
+            "zones": ["Touchpad"],
+            "loop": [
+                {
+                    "type": "fixed",
+                    "colours": [ [0,0,15] ]
+                }
+            ]
+        }
+    ],
+    "AC Sleep": [
+        {
+            "zones": ["Power Button", "HDD LEDs"],
+            "loop": [
+                {
+                    "type": "morph",
+                    "colours": [ [0,0,15], [0,0,0] ]
+                },
+                {
+                    "type": "morph",
+                    "colours": [ [0,0,0], [0,0,15] ]
+                }
+            ]
+        },
+        {
+            "zones": ["Left Keyboard", "Middle-left Keyboard", "Middle-right Keyboard", "Right Keyboard", "Right Speaker", "Left Speaker", "Logo", "Touchpad", "Status LEDs"],
+            "loop": [
+                {
+                    "type": "fixed",
+                    "colours": [ [0,0,0] ]
+                }
+            ]
+        }
+    ],
+    "AC Charged": [
+        {
+            "zones": ["Power Button", "HDD LEDs", "Status LEDs"],
+            "loop": [
+                {
+                    "type": "fixed",
+                    "colours": [ [0,0,15] ]
+                }
+            ]
+        }
+    ],
+    "AC Charging": [
+        {
+            "zones": ["Power Button", "HDD LEDs", "Status LEDs"],
+            "loop": [
+                {
+                    "type": "morph",
+                    "colours": [ [0,0,15], [15,9,0] ]
+                },
+                {
+                    "type": "morph",
+                    "colours": [ [15,9,0], [0,0,15] ]
+                }
+            ]
+        }
+    ],
+    "Battery Sleep": [
+        {
+            "zones": ["Power Button", "HDD LEDs"],
+            "loop": [
+                {
+                    "type": "morph",
+                    "colours": [ [15,9,0], [0,0,0] ]
+                },
+                {
+                    "type": "morph",
+                    "colours": [ [0,0,0], [15,9,0] ]
+                }
+            ]
+        },
+        {
+            "zones": ["Left Keyboard", "Middle-left Keyboard", "Middle-right Keyboard", "Right Keyboard", "Right Speaker", "Left Speaker", "Logo", "Touchpad", "Status LEDs"],
+            "loop": [
+                {
+                    "type": "fixed",
+                    "colours": [ [0,0,0] ]
+                }
+            ]
+        }
+    ],
+    "Battery On": [
+        {
+            "zones": ["Power Button", "HDD LEDs", "Status LEDs"],
+            "loop": [
+                {
+                    "type": "fixed",
+                    "colours": [ [15,9,0] ]
+                }
+            ]
+        }
+    ],
+    "Battery Critical": [
+        {
+            "zones": ["Power Button", "HDD LEDs"],
+            "loop": [
+                {
+                    "type": "blink",
+                    "colours": [ [15,9,0] ]
+                }
+            ]
+        }
+    ]
+}

--- a/alienfx/ui/gtkui/glade/ui.glade
+++ b/alienfx/ui/gtkui/glade/ui.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 -->
+<!-- Generated with glade 3.36.0 -->
 <interface>
   <requires lib="gtk+" version="3.22"/>
   <object class="GtkListStore" id="normal_zone_list_store">
@@ -35,6 +35,7 @@
               <object class="GtkToolButton" id="toolbutton_new_theme">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="tooltip_text" translatable="yes">Create new theme</property>
                 <property name="label" translatable="yes">New</property>
                 <property name="use_underline">True</property>
                 <property name="stock_id">gtk-new</property>
@@ -49,6 +50,7 @@
               <object class="GtkToolButton" id="toolbutton_open_theme">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="tooltip_text" translatable="yes">Open existing theme</property>
                 <property name="label" translatable="yes">Open</property>
                 <property name="use_underline">True</property>
                 <property name="stock_id">gtk-open</property>
@@ -63,6 +65,7 @@
               <object class="GtkToolButton" id="toolbutton_save_theme">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="tooltip_text" translatable="yes">Save theme</property>
                 <property name="label" translatable="yes">Save</property>
                 <property name="use_underline">True</property>
                 <property name="stock_id">gtk-save</property>
@@ -77,6 +80,7 @@
               <object class="GtkToolButton" id="toolbutton_save_theme_as">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="tooltip_text" translatable="yes">Save theme as</property>
                 <property name="label" translatable="yes">Save As</property>
                 <property name="use_underline">True</property>
                 <property name="stock_id">gtk-save-as</property>
@@ -91,6 +95,7 @@
               <object class="GtkToolButton" id="toolbutton_delete_theme">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="tooltip_text" translatable="yes">Delete theme</property>
                 <property name="label" translatable="yes">Delete Theme</property>
                 <property name="use_underline">True</property>
                 <property name="stock_id">gtk-close</property>
@@ -115,6 +120,7 @@
               <object class="GtkToolButton" id="toolbutton_delete">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="tooltip_text" translatable="yes">Delete colour block</property>
                 <property name="label" translatable="yes">Delete Action</property>
                 <property name="use_underline">True</property>
                 <property name="stock_id">gtk-delete</property>
@@ -129,6 +135,7 @@
               <object class="GtkToolButton" id="toolbutton_add">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="tooltip_text" translatable="yes">Add colour block</property>
                 <property name="label" translatable="yes">Add Action</property>
                 <property name="use_underline">True</property>
                 <property name="stock_id">gtk-add</property>
@@ -153,6 +160,7 @@
               <object class="GtkToolButton" id="toolbutton_apply">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="tooltip_text" translatable="yes">Apply theme</property>
                 <property name="label" translatable="yes">Apply</property>
                 <property name="use_underline">True</property>
                 <property name="stock_id">gtk-apply</property>
@@ -545,7 +553,7 @@
       <action-widget response="0">open_theme_cancel</action-widget>
       <action-widget response="0">open_theme_ok</action-widget>
     </action-widgets>
-    <child>
+    <child type="titlebar">
       <placeholder/>
     </child>
   </object>
@@ -696,7 +704,7 @@
       <action-widget response="0">saveas_theme_cancel</action-widget>
       <action-widget response="0">saveas_theme_ok</action-widget>
     </action-widgets>
-    <child>
+    <child type="titlebar">
       <placeholder/>
     </child>
   </object>


### PR DESCRIPTION
I have an m14x r2 and run ubuntu linux, and found your repo which works great save for the Status LEDs. They share the same behavior with the Power/HDD LEDs in that they have power states, so I am adding changes to m14x r* controller files.

Also, added tooltips to the Glade UI-generated GUI.