### PR TITLE
Fix codes for AW17R3.

### DIFF
--- a/alienfx/core/controller_17r3.py
+++ b/alienfx/core/controller_17r3.py
@@ -52,11 +52,10 @@ class AlienFXController17R3(alienfx_controller.AlienFXController):
     LEFT_SPEAKER = 0x0800
     ALIEN_HEAD = 0x0020
     LOGO = 0x0040
-    TOUCH_PAD = 0x4000
-    MEDIA_BAR = 0x1c20
+    TOUCH_PAD = 0x0 # TODO
+    MEDIA_BAR = 0x2000 # Left macro keys
     POWER_BUTTON = 0x0100
-    HDD_LEDS = 0x0080
-    TOUCH_PAD = 0x2000 # Macro Keys
+    HDD_LEDS = 0x0280
 
     # Reset codes
     RESET_ALL_LIGHTS_OFF = 3


### PR DESCRIPTION
I noticed that some codes were not correct for the Alienware 17 R3, which I have.
- The status (0x200) and HDD (0x80) LEDs can be combined as HDD_LEDS (0x280) which then works perfectly for all four indicators (HDD, WIFI, CAPS, NUM) on the top left of the keyboard. They are set together.
- I have assigned MEDIA_BAR to the macro keys on the left side of the keyboard (X, 1 - 5) which work with code 0x2000.
- I could not get the touchpad to light up. This needs further investigation.

With the exception of the touchpad, with thses changes everything else works perfectly. The touchpad will remain unlit.