### PR TITLE
Fixed udev rules file path to be a path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
 )
 
 # Copy the udev rules file
-udev_file = resources.files("alienfx").joinpath("data/etc/udev/rules.d/10-alienfx.rules").open('rb')
+udev_file = resources.files("alienfx").joinpath("data/etc/udev/rules.d/10-alienfx.rules")
 udev_rules_dir = "/etc/udev/rules.d/"
 try:
     if not os.path.exists(udev_rules_dir):


### PR DESCRIPTION
**Describe the bug**
Initial setup failed because path for udev is a Buffered Reader and not really a path.

**To Reproduce**
Steps to reproduce the behavior:
1. Execute **setup.py**
2. Get the error:
```python
Traceback (most recent call last):
  File "/home/daniel/Downloads/alienfx/setup.py", line 89, in <module>
    shutil.copy(udev_file, udev_rules_dir)
  File "/usr/lib/python3.10/shutil.py", line 416, in copy
    dst = os.path.join(dst, os.path.basename(src))
  File "/usr/lib/python3.10/posixpath.py", line 142, in basename
    p = os.fspath(p)
TypeError: expected str, bytes or os.PathLike object, not BufferedReader

```

**Expected behavior**
To setup software correctly.

**System (please complete the following information):**
 - Model: Alienware M15 R7
 - OS: Ubuntu 22.04

