### PR TITLE
Fix TypeError when XDG_CONFIG_HOME is set in environment

### DIFF
--- a/alienfx/core/themefile.py
+++ b/alienfx/core/themefile.py
@@ -76,7 +76,7 @@ class AlienFXThemeFile(object):
                 self._theme_dir = os.path.expanduser("~/.config/alienfx")
             else:
                 self._theme_dir = os.path.join(
-                    os.environ("XDG_CONFIG_HOME"), "alienfx")
+                    os.environ["XDG_CONFIG_HOME"], "alienfx")
             if not os.path.exists(self._theme_dir):
                 os.makedirs(self._theme_dir)
         except Exception as exc:


### PR DESCRIPTION
## Summary

`os.environ` is a mapping object and must be accessed with square brackets (`[]`), not called as a function (`()`).

In `themefile.py`, line 79 uses `os.environ("XDG_CONFIG_HOME")` which raises a `TypeError` for any user who has `XDG_CONFIG_HOME` set in their environment. This exception is silently caught by the surrounding `try/except`, leaving `self._theme_dir` unset. Any subsequent operation that accesses `self._theme_dir` then raises an `AttributeError`, preventing alienfx from applying any theme.

## Fix

```python
# Before
os.environ("XDG_CONFIG_HOME")

# After
os.environ["XDG_CONFIG_HOME"]
```

## Test plan

- [ ] Set `XDG_CONFIG_HOME` in your environment
- [ ] Run `alienfx --theme <name>` and confirm it applies without error
- [ ] Unset `XDG_CONFIG_HOME` and confirm default `~/.config/alienfx` path still works